### PR TITLE
chore: configurable environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ fastlane/Preview.html
 fastlane/screenshots
 
 app/api/url.js
+app/config.js

--- a/app/api/api.js
+++ b/app/api/api.js
@@ -1,9 +1,9 @@
 /* @flow */
 import { create } from 'apisauce';
-import baseUrl from './url';
+import config from '../config';
 
 const api = create({
-  baseURL: `${baseUrl}/index.php?option=com_sportsmanagerapi&q=`,
+  baseURL: `${config.baseUrl}/index.php?option=com_sportsmanagerapi&q=`,
 });
 
 if (__DEV__) {

--- a/app/config.js.tmpl
+++ b/app/config.js.tmpl
@@ -1,0 +1,6 @@
+// @flow
+
+export default {
+    baseUrl: '${API_BASE_URL}',
+    appVersion: '${APP_VERSION}',
+};

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+root="$(dirname "${BASH_SOURCE[0]}")/.."
+
+environment=${1:-development}
+case $environment in
+    development)
+        export API_BASE_URL=http://localhost/liga-tool
+        ;;
+    production)
+        export API_BASE_URL=https://kickern-hamburg.de/de/competitions
+        ;;
+    *) echo "Unknown environment: $environment"; exit 2;;
+esac
+
+export APP_VERSION=$(node -e "process.stdout.write(require('$root/package.json').version)")
+
+envsubst < "$root/app/config.js.tmpl" > "$root/app/config.js"


### PR DESCRIPTION
In order to be able to configure values through environment variables
we want to add a "./scripts/configure.sh" which can be used to generate
a "app/config.js" file with values taken from the environment.
This script generates the config file and therefore needs to be run
before every build / environment switch.