### PR TITLE
chore: move "apply plugin" to bottom to get rid of warnings

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.application"
-apply plugin: "com.google.gms.google-services"
 
 import com.android.build.OutputFile
 
@@ -151,3 +150,5 @@ task copyDownloadableDepsToLibs(type: Copy) {
     from configurations.compile
     into 'libs'
 }
+
+apply plugin: "com.google.gms.google-services"


### PR DESCRIPTION
The gradle plugin "com.google.gms.google-services" should be included
at the bottom of the "build.gradle" file because it overwrites some
other values and will generate warnings during the build process if it
is not at the bottom of the file.