### PR TITLE
chore: check whether the keystore variables are set before using it

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,10 +99,12 @@ android {
     }
     signingConfigs {
         release {
-            storeFile file(LIGATOOL_RELEASE_STORE_FILE)
-            storePassword LIGATOOL_RELEASE_STORE_PASSWORD
-            keyAlias LIGATOOL_RELEASE_KEY_ALIAS
-            keyPassword LIGATOOL_RELEASE_KEY_PASSWORD
+            if (project.hasProperty('LIGATOOL_RELEASE_STORE_FILE')) {
+                storeFile file(LIGATOOL_RELEASE_STORE_FILE)
+                storePassword LIGATOOL_RELEASE_STORE_PASSWORD
+                keyAlias LIGATOOL_RELEASE_KEY_ALIAS
+                keyPassword LIGATOOL_RELEASE_KEY_PASSWORD
+            }
         }
     }
     splits {
@@ -117,7 +119,9 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-            signingConfig signingConfigs.release
+            if (project.hasProperty('LIGATOOL_RELEASE_STORE_FILE')) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     // applicationVariants are e.g. debug, release


### PR DESCRIPTION
After building a freshly cloned version of this repository the build
step fails because the gradle global variables for the release key store
are not set.
This commit adds a check around the signing configs to test whether
these variables are available and only if the are available sets up the
signing config.